### PR TITLE
Fix code scanning alert no. 5: Potential use after free

### DIFF
--- a/src/tspi/obj_rsakey.c
+++ b/src/tspi/obj_rsakey.c
@@ -306,6 +306,7 @@ obj_rsakey_set_key_parms(TSS_HKEY hKey, TCPA_KEY_PARMS *parms)
 	rsakey = (struct tr_rsakey_obj *)obj->data;
 
 	free(rsakey->key.algorithmParms.parms);
+	rsakey->key.algorithmParms.parms = NULL;
 
 	memcpy(&rsakey->key.algorithmParms, parms, sizeof(TCPA_KEY_PARMS));
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/5](https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/5)

To fix the use-after-free error, we need to ensure that `rsakey->key.algorithmParms.parms` is not accessed after it has been freed unless it has been successfully reallocated. The best way to fix this is to set `rsakey->key.algorithmParms.parms` to `NULL` immediately after freeing it. This way, any subsequent access to this pointer will be safe, as accessing a `NULL` pointer will not lead to undefined behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
