### PR TITLE
Fix code scanning alert no. 6: Potential use after free

### DIFF
--- a/src/tspi/obj_rsakey.c
+++ b/src/tspi/obj_rsakey.c
@@ -317,7 +317,9 @@ obj_rsakey_set_key_parms(TSS_HKEY hKey, TCPA_KEY_PARMS *parms)
 			goto done;
 		}
 
-		memcpy(rsakey->key.algorithmParms.parms, parms->parms, parms->parmSize);
+		if (rsakey->key.algorithmParms.parms != NULL) {
+			memcpy(rsakey->key.algorithmParms.parms, parms->parms, parms->parmSize);
+		}
 	} else {
 		rsakey->key.algorithmParms.parms = NULL;
 	}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/6](https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/6)

To fix the use-after-free issue, we need to ensure that the memory is not accessed after it has been freed. This can be achieved by adding a check to ensure that the memory allocation was successful before attempting to access it. If the allocation fails, the function should exit without accessing the freed memory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
