### PR TITLE
Fix code scanning alert no. 4: Potential use after free

### DIFF
--- a/src/tspi/obj_migdata.c
+++ b/src/tspi/obj_migdata.c
@@ -337,13 +337,15 @@ obj_migdata_set_msa_list(TSS_HMIGDATA hMigData, UINT32 msaListSize, BYTE *msaLis
 		result = TSPERR(TSS_E_OUTOFMEMORY);
 		goto done;
 	}
-	digest = migdata->msaList.migAuthDigest;
-	for (i = 0; i < count; i++) {
-		memcpy(digest->digest, msaList, sizeof(digest->digest));
-		msaList += sizeof(digest->digest);
-		digest++;
+	if (migdata->msaList.migAuthDigest != NULL) {
+		digest = migdata->msaList.migAuthDigest;
+		for (i = 0; i < count; i++) {
+			memcpy(digest->digest, msaList, sizeof(digest->digest));
+			msaList += sizeof(digest->digest);
+			digest++;
+		}
+		migdata->msaList.MSAlist = count;
 	}
-	migdata->msaList.MSAlist = count;
 
 	result = obj_migdata_calc_msa_digest(migdata);
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/4](https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/4)

To fix the problem, we need to ensure that the `digest` pointer is only used if the `malloc` call is successful. If `malloc` fails, we should avoid dereferencing `digest` and handle the error appropriately. This can be done by adding a check to ensure that `digest` is not used if `malloc` fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
