### PR TITLE
Fix code scanning alert no. 2: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/tspi/obj_pcrs.c
+++ b/src/tspi/obj_pcrs.c
@@ -189,7 +189,7 @@ obj_pcrs_set_values(TSS_HPCRS hPcrs, TPM_PCR_COMPOSITE *pcrComp)
 {
 	TSS_RESULT result = TSS_SUCCESS;
 	TPM_PCR_SELECTION *select = &(pcrComp->select);
-	UINT16 i, val_idx = 0;
+	UINT32 i, val_idx = 0;
 
 	for (i = 0; i < select->sizeOfSelect * 8; i++) {
 		if (select->pcrSelect[i / 8] & (1 << (i % 8))) {


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/2](https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/2)

To fix the problem, we need to ensure that the variable `i` is of a type that is at least as wide as the type of `select->sizeOfSelect`. The best way to achieve this is to change the type of `i` from `UINT16` to `UINT32`. This change will prevent any potential overflow issues and ensure that the comparison is valid.

- **General Fix:** Change the type of the narrower variable to match or exceed the type of the wider variable in the comparison.
- **Detailed Fix:** Change the type of `i` from `UINT16` to `UINT32` in the function `obj_pcrs_set_values`.
- **Specific Lines to Change:** Update the declaration of `i` on line 192 in the file `src/tspi/obj_pcrs.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
