### PR TITLE
Fix code scanning alert no. 1: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/src/tcs/ps/ps_utils.c
+++ b/src/tcs/ps/ps_utils.c
@@ -345,7 +345,7 @@ int
 init_disk_cache(int fd)
 {
 	UINT32 num_keys = get_num_keys_in_file(fd);
-	UINT16 i;
+	UINT32 i;
 	UINT64 tmp_offset;
 	int rc = 0, offset;
 	struct key_disk_cache *tmp, *prev = NULL;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/1](https://github.com/cooljeanius/trousers-0.3.11.2/security/code-scanning/1)

To fix the problem, we need to ensure that the variable `i` is of the same type as `num_keys` to avoid any type mismatch issues. The best way to fix this is to change the type of `i` from `UINT16` to `UINT32`.

- **General Fix:** Change the type of the narrower variable to match the wider variable.
- **Detailed Fix:** Change the declaration of `i` from `UINT16` to `UINT32` in the `init_disk_cache` function.
- **Specific Lines to Change:** Change the type of `i` on line 348 in the file `src/tcs/ps/ps_utils.c`.
- **Required Changes:** No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
